### PR TITLE
Don't put travis build messages in ##crawl-dev on Freenode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,10 +26,10 @@ notifications:
         on_failure: always
 #        recipients:
 #          - crawl-ref-commits@lists.sourceforge.net
-    irc:
-        channels: "chat.freenode.net##crawl-dev"
-        on_success: change
-        on_failure: always
-        use_notice: true
-        template:
-            - "%{message} (%{branch} - %{commit} #%{build_number} : %{author}): %{build_url}"
+#    irc:
+#        channels: "chat.freenode.net##crawl-dev"
+#        on_success: change
+#        on_failure: always
+#        use_notice: true
+#        template:
+#            - "%{message} (%{branch} - %{commit} #%{build_number} : %{author}): %{build_url}"


### PR DESCRIPTION
We're getting build errors in ##crawl-dev for this repo, which we shouldn't be. Please merge this or otherwise edit the travis config to not make the messages or have them go to an appropriate channel instead. Thanks.