### PR TITLE
Bring back Haste as a level 9 player spell

### DIFF
--- a/crawl-ref/source/beam.cc
+++ b/crawl-ref/source/beam.cc
@@ -3335,6 +3335,7 @@ void bolt::affect_player_enchantment(bool resistible)
     case BEAM_HASTE:
         haste_player(40 + random2(ench_power));
         did_god_conduct(DID_HASTY, 10, blame_player);
+        contaminate_player(750 + random2(500), blame_player);
         obvious_effect = true;
         nasty = false;
         nice  = true;

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -78,8 +78,8 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_PHASE_SHIFT,
     SPELL_SILENCE,
     SPELL_DEFLECT_MISSILES,
-    SPELL_HASTE,
     SPELL_DISCORD,
+    SPELL_HASTE,
 },
 
 {   // Young Poisoner's Handbook
@@ -264,9 +264,9 @@ static const vector<spell_type> spellbook_templates[] =
 {   // Book of Wizardry
     SPELL_FORCE_LANCE,
     SPELL_AGONY,
-    SPELL_HASTE,
     SPELL_INVISIBILITY,
     SPELL_SPELLFORGED_SERVITOR,
+    SPELL_HASTE,
 },
 #endif
 

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -78,6 +78,7 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_PHASE_SHIFT,
     SPELL_SILENCE,
     SPELL_DEFLECT_MISSILES,
+    SPELL_HASTE,
     SPELL_DISCORD,
 },
 

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -263,6 +263,7 @@ static const vector<spell_type> spellbook_templates[] =
 {   // Book of Wizardry
     SPELL_FORCE_LANCE,
     SPELL_AGONY,
+    SPELL_HASTE,
     SPELL_INVISIBILITY,
     SPELL_SPELLFORGED_SERVITOR,
 },

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -4619,7 +4619,10 @@ bool haste_player(int turns, bool rageext)
     else if (you.duration[DUR_HASTE] > threshold * BASELINE_DELAY)
         mpr("You already have as much speed as you can handle.");
     else if (!rageext)
+    {
         mpr("You feel as though your hastened speed will last longer.");
+        contaminate_player(750 + random2(500), true); // always deliberate
+    }
 
     you.increase_duration(DUR_HASTE, turns, threshold);
 

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -192,7 +192,7 @@ static const struct spell_desc spelldata[] =
     SPTYP_CHARMS,
     SPFLAG_DIR_OR_TARGET | SPFLAG_HELPFUL | SPFLAG_HASTY | SPFLAG_SELFENCH
         | SPFLAG_UTILITY,
-    6,
+    9,
     200,
     LOS_RADIUS, LOS_RADIUS,
     5, 0,

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -714,18 +714,20 @@ static void _handle_magic_contamination()
     // every turn instead of every 20 turns, so everything has been multiplied
     // by 50 and scaled to you.time_taken.
 
-    //Increase contamination each turn while invisible
     if (you.duration[DUR_INVIS])
         added_contamination += INVIS_CONTAM_PER_TURN;
-    //If not invisible, normal dissipation
-    else
-        added_contamination -= 25;
+    if (you.duration[DUR_HASTE])
+        added_contamination += INVIS_CONTAM_PER_TURN;
 
     // The Orb halves dissipation (well a bit more, I had to round it),
     // but won't cause glow on its own -- otherwise it'd spam the player
     // with messages about contamination oscillating near zero.
     if (you.magic_contamination && player_has_orb())
         added_contamination += 13;
+
+    // Normal dissipation
+    if (!you.duration[DUR_INVIS] && !you.duration[DUR_HASTE])
+        added_contamination -= 25;
 
     // Scaling to turn length
     added_contamination = div_rand_round(added_contamination * you.time_taken,


### PR DESCRIPTION
This is basically the Hellcrawl solution. If it's a level 9 spell, it's not 'trivially correct spell on every 3 runer spellcaster', it's 'significant investment with a significant reward, and a convenience in extended where you have access to infinite potions of haste if you scum long enough anyways'.