### PR TITLE
Return Repel Missiles as a spell

### DIFF
--- a/crawl-ref/source/attribute-type.h
+++ b/crawl-ref/source/attribute-type.h
@@ -61,9 +61,7 @@ enum attribute_type
     ATTR_BARBS_MSG,            // Have we already printed a message on move?
 #endif
     ATTR_BARBS_POW,            // How badly we are currently skewered
-#if TAG_MAJOR_VERSION == 34
     ATTR_REPEL_MISSILES,       // Repel missiles active
-#endif
     ATTR_DEFLECT_MISSILES,     // Deflect missiles active
     ATTR_PORTAL_PROJECTILE,    // Accuracy bonus during portal projectile
     ATTR_GOD_WRATH_XP,         // How much XP before our next god wrath check?

--- a/crawl-ref/source/book-data.h
+++ b/crawl-ref/source/book-data.h
@@ -6,6 +6,7 @@ static const vector<spell_type> spellbook_templates[] =
     SPELL_MAGIC_DART,
     SPELL_BLINK,
     SPELL_CALL_IMP,
+    SPELL_REPEL_MISSILES,
     SPELL_SLOW,
     SPELL_CONJURE_FLAME,
     SPELL_MEPHITIC_CLOUD,
@@ -188,6 +189,7 @@ static const vector<spell_type> spellbook_templates[] =
 {   // Book of Air
     SPELL_SHOCK,
     SPELL_SWIFTNESS,
+    SPELL_REPEL_MISSILES,
     SPELL_DISCHARGE,
     SPELL_AIRSTRIKE,
     SPELL_LIGHTNING_BOLT,

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5637,14 +5637,26 @@ int player::missile_deflection() const
 
 void player::ablate_deflection()
 {
+    const int orig_defl = missile_deflection();
+
+    bool did_something = false;
     if (attribute[ATTR_DEFLECT_MISSILES])
     {
         const int power = calc_spell_power(SPELL_DEFLECT_MISSILES, true);
         if (one_chance_in(2 + power / 8))
         {
             attribute[ATTR_DEFLECT_MISSILES] = 0;
-            mprf(MSGCH_DURATION, "You feel less protected from missiles.");
+            did_something = true;
         }
+    }
+
+    if (did_something)
+    {
+        // We might also have the effect from a non-expiring source.
+        mprf(MSGCH_DURATION, "You feel %s from missiles.",
+                             missile_deflection() < orig_defl
+                                 ? "less protected"
+                                 : "your spell is no longer protecting you");
     }
 }
 

--- a/crawl-ref/source/player.cc
+++ b/crawl-ref/source/player.cc
@@ -5624,7 +5624,8 @@ int player::missile_deflection() const
     if (attribute[ATTR_DEFLECT_MISSILES])
         return 2;
 
-    if (get_mutation_level(MUT_DISTORTION_FIELD) == 3
+    if (attribute[ATTR_REPEL_MISSILES]
+        || get_mutation_level(MUT_DISTORTION_FIELD) == 3
         || you.wearing_ego(EQ_ALL_ARMOUR, SPARM_REPULSION)
         || scan_artefacts(ARTP_RMSL, true)
         || have_passive(passive_t::upgraded_storm_shield))
@@ -5646,6 +5647,15 @@ void player::ablate_deflection()
         if (one_chance_in(2 + power / 8))
         {
             attribute[ATTR_DEFLECT_MISSILES] = 0;
+            did_something = true;
+        }
+    }
+    else if (attribute[ATTR_REPEL_MISSILES])
+    {
+        const int power = calc_spell_power(SPELL_REPEL_MISSILES, true);
+        if (one_chance_in(2 + power / 8))
+        {
+            attribute[ATTR_REPEL_MISSILES] = 0;
             did_something = true;
         }
     }

--- a/crawl-ref/source/spl-cast.cc
+++ b/crawl-ref/source/spl-cast.cc
@@ -1846,6 +1846,9 @@ static spret_type _do_cast(spell_type spell, int powc, const dist& spd,
     case SPELL_REGENERATION:
         return cast_regen(powc, fail);
 
+    case SPELL_REPEL_MISSILES:
+        return missile_prot(powc, fail);
+
     case SPELL_DEFLECT_MISSILES:
         return deflection(powc, fail);
 

--- a/crawl-ref/source/spl-data.h
+++ b/crawl-ref/source/spl-data.h
@@ -780,7 +780,7 @@ static const struct spell_desc spelldata[] =
 {
     SPELL_REPEL_MISSILES, "Repel Missiles",
     SPTYP_CHARMS | SPTYP_AIR,
-    SPFLAG_MONSTER,
+    SPFLAG_NONE,
     2,
     50,
     -1, -1,

--- a/crawl-ref/source/spl-goditem.cc
+++ b/crawl-ref/source/spl-goditem.cc
@@ -329,7 +329,7 @@ static void _dispellable_player_buffs(player_debuff_effects &buffs)
 {
     // attributes
     static const attribute_type dispellable_attributes[] = {
-        ATTR_DEFLECT_MISSILES,
+        ATTR_REPEL_MISSILES, ATTR_DEFLECT_MISSILES,
     };
 
     for (auto attribute : dispellable_attributes)

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -191,6 +191,14 @@ spret_type corpse_armour(int pow, bool fail)
     return SPRET_SUCCESS;
 }
 
+spret_type missile_prot(int pow, bool fail)
+{
+    fail_check();
+    you.attribute[ATTR_REPEL_MISSILES] = 1;
+    mpr("You feel protected from missiles.");
+    return SPRET_SUCCESS;
+}
+
 spret_type deflection(int pow, bool fail)
 {
     fail_check();

--- a/crawl-ref/source/spl-selfench.cc
+++ b/crawl-ref/source/spl-selfench.cc
@@ -204,6 +204,9 @@ spret_type deflection(int pow, bool fail)
     fail_check();
     you.attribute[ATTR_DEFLECT_MISSILES] = 1;
     mpr("You feel very safe from missiles.");
+    // Replace RMsl, if active.
+    if (you.attribute[ATTR_REPEL_MISSILES])
+        you.attribute[ATTR_REPEL_MISSILES] = 0;
 
     return SPRET_SUCCESS;
 }

--- a/crawl-ref/source/spl-selfench.h
+++ b/crawl-ref/source/spl-selfench.h
@@ -13,6 +13,7 @@ int harvest_corpses(const actor &harvester,
                     bool dry_run = false, bool defy_god = false);
 spret_type corpse_armour(int pow, bool fail);
 
+spret_type missile_prot(int pow, bool fail);
 spret_type deflection(int pow, bool fail);
 
 spret_type cast_regen(int pow, bool fail);

--- a/crawl-ref/source/spl-util.cc
+++ b/crawl-ref/source/spl-util.cc
@@ -29,6 +29,7 @@
 #include "options.h"
 #include "orb.h"
 #include "output.h"
+#include "player.h"
 #include "prompt.h"
 #include "religion.h"
 #include "spl-book.h"
@@ -351,6 +352,17 @@ static void _remove_spell_attributes(spell_type spell)
         {
             const int orig_defl = you.missile_deflection();
             you.attribute[ATTR_DEFLECT_MISSILES] = 0;
+            mprf(MSGCH_DURATION, "You feel %s from missiles.",
+                                 you.missile_deflection() < orig_defl
+                                 ? "less protected"
+                                 : "your spell is no longer protecting you");
+        }
+        break;
+    case SPELL_REPEL_MISSILES:
+        if (you.attribute[ATTR_REPEL_MISSILES])
+        {
+            const int orig_defl = you.missile_deflection();
+            you.attribute[ATTR_REPEL_MISSILES] = 0;
             mprf(MSGCH_DURATION, "You feel %s from missiles.",
                                  you.missile_deflection() < orig_defl
                                  ? "less protected"
@@ -1139,6 +1151,17 @@ string spell_uselessness_reason(spell_type spell, bool temp, bool prevent,
         // mere corona is not enough, but divine light blocks it completely
         if (temp && (you.haloed() || !prevent && have_passive(passive_t::halo)))
             return "darkness is useless against divine light.";
+        break;
+
+    case SPELL_REPEL_MISSILES:
+        if (temp && (you.get_mutation_level(MUT_DISTORTION_FIELD) == 3
+                     || you.scan_artefacts(ARTP_RMSL, true)
+                     || you.wearing_ego(EQ_ALL_ARMOUR, SPARM_REPULSION)
+                     || you.attribute[ATTR_REPEL_MISSILES]
+                     || you.attribute[ATTR_DEFLECT_MISSILES]))
+        {
+            return "you're already repelling missiles.";
+        }
         break;
 
     case SPELL_DEFLECT_MISSILES:


### PR DESCRIPTION
It now exists alongside the scarf (having two sources doesn't stack, one isn't enough), and is back in the Air Elementalist starting book.