### PR TITLE
Re-adding Healer for Gooncrawl.

### DIFF
--- a/crawl-ref/source/dat/database/shout.txt
+++ b/crawl-ref/source/dat/database/shout.txt
@@ -294,6 +294,10 @@ Wanderer player ghost
 Priest player ghost
 
 @player ghost@
+%%%%
+Healer player ghost
+
+@player ghost@
 ########################################
 # Shouts by monster symbol
 ########################################

--- a/crawl-ref/source/dat/descript/backgrounds.txt
+++ b/crawl-ref/source/dat/descript/backgrounds.txt
@@ -73,6 +73,11 @@ Gladiator
 Gladiators are ready for the arena with light armour, nets, and a weapon of
 their choice.
 %%%%
+Healer
+
+Healers are followers of Elyvilon the Healer, a pacifist god that protects and 
+heals the followers who adhere to Elyvilon's tenants.
+%%%%
 Hunter
 
 Hunters carry a ranged weapon of their choice, and are also equipped with light

--- a/crawl-ref/source/evoke.cc
+++ b/crawl-ref/source/evoke.cc
@@ -1869,8 +1869,8 @@ void handle_playing_harp()
         return;
     }
 
-    // Heal for 10 + (1 * Evocations), can adjust later if too weak/strong
-    const int base_pow = 10 + you.skill(SK_EVOCATIONS, 1);
+    // Heal for 5 + (.75 * Evocations), can adjust later if too weak/strong
+    const int base_pow = 5 + you.skill(SK_EVOCATIONS, .75);
     inc_hp(base_pow);
 
     // Make a small bit of noise for flavor

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -321,9 +321,9 @@ static const map<job_type, job_def> job_data =
     4, 4, 4,
     { SP_DEEP_DWARF, SP_HILL_ORC, SP_NAGA, SP_MINOTAUR, SP_BASE_DRACONIAN,
 	  SP_GARGOYLE, },
-    { "robe plus:1", "potion of curing", "potion of heal wounds" },
+    { "robe plus:1", "potion of curing", "potion of heal wounds", "harp of healing" },
     WCHOICE_NONE,
-    { {SK_FIGHTING, 1}, {SK_DODGING, 2}, {SK_INVOCATIONS, 3} },
+    { {SK_FIGHTING, 1}, {SK_DODGING, 2}, {SK_INVOCATIONS, 3}, {SK_EVOCATIONS, 1}, },
 } },
 #if TAG_MAJOR_VERSION == 34
 { JOB_JESTER, {

--- a/crawl-ref/source/job-data.h
+++ b/crawl-ref/source/job-data.h
@@ -315,16 +315,17 @@ static const map<job_type, job_def> job_data =
     WCHOICE_PLAIN,
     { {SK_FIGHTING, 2}, {SK_DODGING, 1}, {SK_INVOCATIONS, 5}, {SK_WEAPON, 3}, },
 } },
-#if TAG_MAJOR_VERSION == 34
+
 { JOB_HEALER, {
     "He", "Healer",
-    0, 0, 0,
-    { },
-    { },
+    4, 4, 4,
+    { SP_DEEP_DWARF, SP_HILL_ORC, SP_NAGA, SP_MINOTAUR, SP_BASE_DRACONIAN,
+	  SP_GARGOYLE, },
+    { "robe plus:1", "potion of curing", "potion of heal wounds" },
     WCHOICE_NONE,
-    { },
+    { {SK_FIGHTING, 1}, {SK_DODGING, 2}, {SK_INVOCATIONS, 3} },
 } },
-
+#if TAG_MAJOR_VERSION == 34
 { JOB_JESTER, {
     "Jr", "Jester",
     0, 0, 0,

--- a/crawl-ref/source/job-type.h
+++ b/crawl-ref/source/job-type.h
@@ -21,8 +21,8 @@ enum job_type
     JOB_VENOM_MAGE,
     JOB_CHAOS_KNIGHT,
     JOB_TRANSMUTER,
-#if TAG_MAJOR_VERSION == 34
     JOB_HEALER,
+#if TAG_MAJOR_VERSION == 34
     JOB_STALKER,
 #endif
     JOB_MONK,

--- a/crawl-ref/source/newgame.cc
+++ b/crawl-ref/source/newgame.cc
@@ -1088,7 +1088,7 @@ static job_group jobs_order[] =
         "Zealot",
         coord_def(15, 0), 20,
         { JOB_BERSERKER, JOB_ABYSSAL_KNIGHT, JOB_CHAOS_KNIGHT,
-          JOB_DEATH_KNIGHT, JOB_PRIEST }
+          JOB_DEATH_KNIGHT, JOB_PRIEST, JOB_HEALER }
     },
     {
         "Warrior-mage",

--- a/crawl-ref/source/ng-restr.cc
+++ b/crawl-ref/source/ng-restr.cc
@@ -36,7 +36,8 @@ static bool _banned_combination(job_type job, species_type species)
             || job == JOB_ABYSSAL_KNIGHT
             || job == JOB_DEATH_KNIGHT
             || job == JOB_MONK
-            || job == JOB_PRIEST)
+            || job == JOB_PRIEST
+			|| job == JOB_HEALER)
         {
             return true;
         }
@@ -48,10 +49,26 @@ static bool _banned_combination(job_type job, species_type species)
         }
         break;
     case SP_MUMMY:
+		if (job == JOB_HEALER)
+		{
+			return true;
+		}
+		break;
     case SP_GHOUL:
+		if (job == JOB_HEALER)
+		{
+			return true;
+		}
+		break;
     case SP_VAMPIRE:
+		if (job == JOB_HEALER)
+		{
+			return true;
+		}
+		break;
     case SP_DEMONSPAWN:
-        if (job == JOB_PRIEST)
+        if (job == JOB_PRIEST
+			|| job == JOB_HEALER)
         {
             return true;
         }

--- a/crawl-ref/source/ng-setup.cc
+++ b/crawl-ref/source/ng-setup.cc
@@ -384,6 +384,11 @@ static void _give_items_skills(const newgame_def& ng)
         you.religion = GOD_ZIN;
         you.piety = 45;
         break;
+	
+	case JOB_HEALER:
+		you.religion = GOD_ELYVILION;
+		you.piety = 55;
+		break;
 
     case JOB_WANDERER:
         create_wanderer();

--- a/crawl-ref/source/tilepick-p.cc
+++ b/crawl-ref/source/tilepick-p.cc
@@ -887,7 +887,7 @@ void tilep_job_default(int job, dolls_data *doll)
             parts[TILEP_PART_ARM]   = TILEP_ARM_GLOVE_WHITE;
             parts[TILEP_PART_BOOTS] = TILEP_BOOTS_SHORT_BROWN;
             break;
-#if TAG_MAJOR_VERSION == 34
+
         case JOB_HEALER:
             parts[TILEP_PART_BODY]  = TILEP_BODY_ROBE_WHITE;
             parts[TILEP_PART_ARM]   = TILEP_ARM_GLOVE_WHITE;
@@ -895,7 +895,6 @@ void tilep_job_default(int job, dolls_data *doll)
             parts[TILEP_PART_BOOTS] = TILEP_BOOTS_SHORT_BROWN;
             parts[TILEP_PART_HELM]  = TILEP_HELM_FHELM_HEALER;
             break;
-#endif
 
         case JOB_NECROMANCER:
             parts[TILEP_PART_BODY]  = TILEP_BODY_ROBE_BLACK;


### PR DESCRIPTION
The first commit is just the basic class in case you don't want to add the Harp to the Healer or change the tuning of the Harp. The tuning is just me knocking out two birds with one stone, at 27 Evocations it's 25.25 hp healed instead of 37 hp healed, which brings it close to a Potion of Heal Wounds 23 hp healed.

The Harp fits the class thematically, and compensates for the lack of the 1 star piety heal/pacification from Elyvilon, otherwise I doubt anyone would play the class as is, save the really masochistic.

Just ignore the last commit though, the menu didn't switch to my gooncrawl_healer branch like I thought it did. 