### PR TITLE
various unrand upgrades

### DIFF
--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -209,7 +209,7 @@ BOOL:    chaotic
 BRAND:   SPWPN_VORPAL
 
 NAME:    sword of Power
-OBJ:     OBJ_WEAPONS/WPN_GREAT_SWORD
+OBJ:     OBJ_WEAPONS/WPN_TRIPLE_SWORD
 PLUS:    +0 # Set on wield
 HP:      +20
 COLOUR:  RED
@@ -503,7 +503,7 @@ LIFE:     1
 BOOL:     poison, nogen, notac
 
 NAME:     trident of the Octopus King
-OBJ:      OBJ_WEAPONS/WPN_TRIDENT
+OBJ:      OBJ_WEAPONS/WPN_DEMON_TRIDENT
 PLUS:     +8 # Messed with sometimes
 COLOUR:   ETC_WATER
 TILE:     urand_octopus_king
@@ -613,7 +613,7 @@ TILE_EQ:  undeadhunter
 LIFE:     1
 
 NAME:    whip "Snakebite"
-OBJ:     OBJ_WEAPONS/WPN_WHIP
+OBJ:     OBJ_WEAPONS/WPN_DEMON_WHIP
 INSCRIP: curare,
 PLUS:    +8
 COLOUR:  DARKGREY
@@ -675,13 +675,13 @@ LIFE:    1
 
 NAME:    robe of Augmentation
 OBJ:     OBJ_ARMOUR/ARM_ROBE
-PLUS:    +4
+PLUS:    +8
 COLOUR:  LIGHTRED
 TILE:    urand_augmentation
 TILE_EQ: robe_white_blue
-STR:     4
-INT:     4
-DEX:     4
+STR:     8
+INT:     8
+DEX:     8
 
 NAME:     cloak of the Thief
 OBJ:      OBJ_ARMOUR/ARM_CLOAK
@@ -690,9 +690,8 @@ PLUS:     +2
 COLOUR:   ETC_DARK
 TILE:     urand_thief
 TILE_EQ:  black
-SLAY:     -2
-STEALTH:  1
-BOOL:     seeinv, fog
+STEALTH:  2
+BOOL:     seeinv, fog, blink
 
 # TAG_MAJOR_VERSION == 34
 NAME:    large shield "Bullseye"
@@ -706,11 +705,11 @@ BOOL:    nogen, notac
 
 NAME:    crown of Dyrovepreva
 OBJ:     OBJ_ARMOUR/ARM_HAT
-PLUS:    +3
+PLUS:    +5
 COLOUR:  ETC_JEWEL
 TILE:    urand_dyrovepreva
 TILE_EQ: dyrovepreva
-INT:     2
+INT:     5
 BOOL:    elec, seeinv
 
 NAME:     hat of the Bear Spirit
@@ -731,7 +730,7 @@ COLOUR:   LIGHTMAGENTA
 TILE:     urand_misfortune
 TILE_EQ:  robe_misfortune
 EV:       5
-BOOL:     harm, mutate, drain, slow, corrode
+BOOL:     harm, mutate, drain, slow, corrode, notac
 
 # TAG_MAJOR_VERSION == 34
 NAME:     cloak of Flash
@@ -761,27 +760,31 @@ PLUS:    27
 COLOUR:  ETC_GOLD
 TILE:    urand_lear
 TILE_EQ: lears_hauberk
+MAGIC:   3
+LIFE:    3
 BOOL:    special
 
 NAME:    skin of Zhor
 OBJ:     OBJ_ARMOUR/ARM_ANIMAL_SKIN
-PLUS:    +4
+PLUS:    +8
 COLOUR:  BROWN
 TILE:    urand_zhor
 TILE_EQ: zhor
 COLD:    3
-BOOL:    seeinv
+REGEN:   3
+BOOL:    seeinv,rmsl
 INSCRIP: Hibernate
 
 ENUM:    SALAMANDER
 NAME:    salamander hide armour
 OBJ:     OBJ_ARMOUR/ARM_LEATHER_ARMOUR
-PLUS:    +3
+PLUS:    +8
 COLOUR:  ETC_FIRE
 TILE:    urand_salamander
 TILE_EQ: leather_red
-FIRE:    2
+FIRE:    3
 BOOL:    berserk
+SLAY:    6
 
 NAME:    gauntlets of War
 OBJ:     OBJ_ARMOUR/ARM_GLOVES
@@ -789,7 +792,7 @@ PLUS:    +3
 COLOUR:  BROWN
 TILE:    urand_war
 TILE_EQ: glove_black
-SLAY:    5
+SLAY:    6
 
 NAME:    shield of Resistance
 OBJ:     OBJ_ARMOUR/ARM_SHIELD
@@ -810,6 +813,7 @@ TILE_EQ: robe_red2
 BRAND:   SPARM_ARCHMAGI
 INT:     5
 MAGIC:   -2
+BOOL:    notac
 
 ENUM:    MAXWELL
 NAME:    Maxwell's patent armour
@@ -819,7 +823,7 @@ COLOUR:  LIGHTGREEN
 TILE:    urand_maxwell
 TILE_EQ: maxwell
 MAGIC:   1
-BOOL:    nospell, notelep, elec, rCorr
+BOOL:    notelep, elec, rCorr, clarity
 
 ENUM:    DRAGONMASK
 NAME:    mask of the Dragon
@@ -839,7 +843,7 @@ COLOUR:   ETC_DARK
 TILE:     urand_night
 TILE_EQ:  robe_of_night
 MAGIC:    1
-BOOL:     seeinv
+BOOL:     seeinv,fog,blink,fly,invis
 VALUE:    600
 
 NAME:    scales of the Dragon King
@@ -850,9 +854,9 @@ TILE:    urand_dragon_king
 TILE_EQ: dragonarm_gold
 MAGIC:   1
 
-NAME:    hat of the Alchemist
+NAME:    hatte of the Alchemist
 OBJ:     OBJ_ARMOUR/ARM_HAT
-PLUS:    -2
+PLUS:    +1
 COLOUR:  LIGHTMAGENTA
 TILE:    urand_alchemist
 TILE_EQ: turban_purple
@@ -866,11 +870,11 @@ ENUM:    FENCERS
 NAME:    fencer's gloves
 INSCRIP: +Riposte
 OBJ:     OBJ_ARMOUR/ARM_GLOVES
-PLUS:    +0
+PLUS:    +5
 COLOUR:  WHITE
 TILE:    urand_fencer
 TILE_EQ: glove_white
-DEX:     3
+DEX:     10
 VALUE:   400
 
 NAME:     cloak of Starlight
@@ -892,10 +896,10 @@ TILE:     urand_ratskin_cloak
 TILE_EQ:  ratskin
 INSCRIP:  +Rats
 STR:      -1
-INT:      -1
-DEX:      2
+DEX:      3
 LIFE:     1
-BOOL:     poison
+COLD:     1 
+BOOL:     poison,rcorr
 
 NAME:     shield of the Gong
 OBJ:      OBJ_ARMOUR/ARM_SHIELD
@@ -953,7 +957,7 @@ BOOL:    curse
 
 NAME:    ring of Phasing
 OBJ:     OBJ_JEWELLERY/RING_EVASION
-PLUS:    +9
+PLUS:    +12
 COLOUR:  ETC_POISON
 TILE:    urand_phasing
 
@@ -1076,11 +1080,11 @@ NAME:     ring of the Octopus King
 OBJ:      OBJ_JEWELLERY/RING_LOUDNESS
 COLOUR:   ETC_WATER
 TILE:     urand_octoring
-AC:       1
-EV:       1
-STR:      1
-INT:      1
-DEX:      1
+AC:       2
+EV:       2
+STR:      2
+INT:      2
+DEX:      2
 BOOL:     unided, no_upgrade, notac
 
 # Meatsprint only. The type is adjusted to the biggest two-handed axe the
@@ -1154,6 +1158,7 @@ NAME:     arc blade
 INSCRIP:  discharge,
 OBJ:      OBJ_WEAPONS/WPN_RAPIER
 PLUS:     +8
+BASE_DAM: +2
 COLOUR:   ETC_ELECTRICITY
 TILE:     urand_arc_blade
 TILE_EQ:  arc_blade
@@ -1176,7 +1181,7 @@ OBJ:     OBJ_WEAPONS/WPN_LAJATANG
 COLOUR:  ETC_SILVER
 TILE:    urand_order
 TILE_EQ: order
-PLUS:    +7
+PLUS:    +9
 BOOL:    rMut
 
 ENUM:     FIRESTARTER
@@ -1319,8 +1324,8 @@ COLOUR:   ETC_VEHUMET
 TILE:     urand_thermic_engine
 TILE_EQ:  thermic_engine
 BRAND:    SPWPN_FLAMING
-FIRE:     -1
-COLD:     -1
+FIRE:     +1
+COLD:     +1
 
 NAME:     hand wraps "Fists of Thunder"
 INSCRIP:  elec
@@ -1329,7 +1334,7 @@ TYPE:     hand wraps
 COLOUR:   BLUE
 TILE:     urand_fists_of_thunder
 TILE_EQ:  glove_white
-SLAY:     2
+SLAY:     4
 BOOL:     elec
 
 ENUM:     RIFT

--- a/crawl-ref/source/art-data.txt
+++ b/crawl-ref/source/art-data.txt
@@ -187,6 +187,7 @@ TILE_EQ: axe_trog
 VALUE:   800
 ANGRY:   50
 BRAND:   SPWPN_ANTIMAGIC
+BOOL:    notac
 
 NAME:    mace of Variability
 OBJ:     OBJ_WEAPONS/WPN_GREAT_MACE
@@ -211,7 +212,7 @@ BRAND:   SPWPN_VORPAL
 NAME:    sword of Power
 OBJ:     OBJ_WEAPONS/WPN_TRIPLE_SWORD
 PLUS:    +0 # Set on wield
-HP:      +20
+HP:      +40
 COLOUR:  RED
 TILE:    spwpn_sword_of_power
 TILE_EQ: sword_of_power
@@ -254,7 +255,8 @@ TILE:    spwpn_scythe_of_curses
 TILE_EQ: finisher
 BRAND:   SPWPN_DRAINING
 VALUE:   800
-BOOL:    curse
+LIFE:    2
+BOOL:    curse, notac
 
 NAME:    sceptre of Torment
 INSCRIP: torment
@@ -329,6 +331,7 @@ TILE:    urand_bloodbane
 TILE_EQ: bloodbane
 BRAND:   SPWPN_VORPAL
 ANGRY:   5
+DEX:     8
 BOOL:    berserk
 STEALTH: -1
 
@@ -393,6 +396,7 @@ TILE_EQ:  morg
 BRAND:    SPWPN_PAIN
 INT:      5
 MAGIC:    1
+BOOL:     notac
 
 NAME:    scythe "Finisher"
 OBJ:     OBJ_WEAPONS/WPN_SCYTHE
@@ -450,9 +454,9 @@ COLOUR:   ETC_HOLY
 TILE:     unrand_zealot_sword
 TILE_EQ:  zealot_sword
 BRAND:    SPWPN_HOLY_WRATH
-EV:       3
-ANGRY:    5
+EV:       5
 LIFE:     1
+BOOL:     berserk
 
 NAME:    arbalest "Damnation"
 INSCRIP: damnation,
@@ -540,7 +544,6 @@ PLUS:     +9
 COLOUR:   ETC_DARK
 TILE:     urand_sniper
 TILE_EQ:  sniper
-BASE_DELAY: +4
 BRAND:    SPWPN_VORPAL
 BOOL:     seeinv
 INSCRIP:  Acc+∞
@@ -599,7 +602,7 @@ PLUS:    +11
 COLOUR:  ETC_MUTAGENIC
 TILE:    urand_plutonium
 TILE_EQ: plutonium_sword
-BOOL:    mutate, chaotic
+BOOL:    mutate, chaotic, rmut
 STEALTH: -1
 VALUE:   1000
 
@@ -649,7 +652,10 @@ NAME:     captain's cutlass
 OBJ:      OBJ_WEAPONS/WPN_RAPIER
 TYPE:     cutlass
 INSCRIP:  disarm
+BASE_DAM: +2
 PLUS:     +7
+AC:       7
+EV:       7
 COLOUR:   DARKGREY
 TILE:     urand_cutlass
 TILE_EQ:  capt_cutlass
@@ -672,6 +678,7 @@ TILE_EQ: lshield_of_ignorance
 INT:     -4
 BRAND:	 SPARM_PROTECTION
 LIFE:    1
+BOOL:    notac
 
 NAME:    robe of Augmentation
 OBJ:     OBJ_ARMOUR/ARM_ROBE
@@ -746,7 +753,7 @@ ENUM:     BOOTS_ASSASSIN
 NAME:     boots of the Assassin
 OBJ:      OBJ_ARMOUR/ARM_BOOTS
 INSCRIP:  Detection Stab+
-PLUS:     +2
+PLUS:     +4
 COLOUR:   BROWN
 TILE:     urand_assassin
 TILE_EQ:  middle_gray
@@ -831,8 +838,9 @@ OBJ:     OBJ_ARMOUR/ARM_HAT
 COLOUR:  ETC_SHIMMER_BLUE
 TILE:    urand_dragonmask
 TILE_EQ: art_dragonhelm
-MAGIC:   1
+MAGIC:   3
 SLAY:    3
+PLUS:    3
 BOOL:    seeinv
 
 NAME:     robe of Night
@@ -875,11 +883,12 @@ COLOUR:  WHITE
 TILE:    urand_fencer
 TILE_EQ: glove_white
 DEX:     10
+EV:      3
 VALUE:   400
 
 NAME:     cloak of Starlight
 OBJ:      OBJ_ARMOUR/ARM_CLOAK
-PLUS:     +1
+PLUS:     +4
 COLOUR:   ETC_ICE
 TILE:     urand_starlight
 TILE_EQ:  white
@@ -917,14 +926,14 @@ OBJ:     OBJ_JEWELLERY/AMU_INACCURACY
 COLOUR:  ETC_ELECTRICITY
 TILE:    urand_air
 EV:      5
-BOOL:    elec, fly, rmsl
+BOOL:    elec, fly, rmsl, notac
 
 NAME:    ring of Shadows
 INSCRIP: Umbra
 OBJ:     OBJ_JEWELLERY/RING_STEALTH
 COLOUR:  ETC_DARK
 TILE:    urand_shadows
-BOOL:    inv
+BOOL:    inv, notac
 VALUE:   400
 
 # TAG_MAJOR_VERSION == 34
@@ -943,7 +952,7 @@ COLOUR:  ETC_POISON
 TILE:    urand_four_winds
 LIFE:    1
 MAGIC:   3
-BOOL:    clarity
+BOOL:    clarity, notac
 
 NAME:    necklace of Bloodlust
 OBJ:     OBJ_JEWELLERY/AMU_RAGE
@@ -973,6 +982,7 @@ COLOUR:  ETC_ENCHANT
 TILE:    urand_mage
 INT:     3
 MAGIC:   2
+BOOL:    notac
 
 NAME:     brooch of Shielding
 OBJ:      OBJ_JEWELLERY/AMU_REFLECTION
@@ -988,7 +998,7 @@ PLUS:     +3
 COLOUR:   ETC_MIST
 TILE:     urand_clouds
 TILE_EQ:  robe_clouds
-BOOL:     elec
+BOOL:     elec, notac
 
 NAME:     hat of Pondering
 OBJ:      OBJ_ARMOUR/ARM_HAT
@@ -1000,6 +1010,7 @@ BRAND:    SPARM_PONDEROUSNESS
 INT:      +5
 MP:       +10
 MAGIC:    1
+BOOL:     notac
 
 ENUM:     DEMON_AXE
 NAME:     obsidian axe
@@ -1009,7 +1020,7 @@ COLOUR:   ETC_UNHOLY
 TILE:     spwpn_demon_axe
 TILE_EQ:  demon_axe
 BRAND:    SPWPN_VORPAL
-BOOL:     evil, seeinv, fly, curse
+BOOL:     evil, seeinv, fly, curse, notac
 
 NAME:     lightning scales
 OBJ:      OBJ_ARMOUR/ARM_NAGA_BARDING
@@ -1080,11 +1091,11 @@ NAME:     ring of the Octopus King
 OBJ:      OBJ_JEWELLERY/RING_LOUDNESS
 COLOUR:   ETC_WATER
 TILE:     urand_octoring
-AC:       2
-EV:       2
-STR:      2
-INT:      2
-DEX:      2
+AC:       3
+EV:       3
+STR:      3
+INT:      3
+DEX:      3
 BOOL:     unided, no_upgrade, notac
 
 # Meatsprint only. The type is adjusted to the biggest two-handed axe the
@@ -1193,7 +1204,9 @@ TILE:     urand_firestarter
 TILE_EQ:  firestarter
 PLUS:     +7
 BRAND:    SPWPN_FLAMING
-FIRE:     2
+FIRE:     3
+AC:       6
+HP:       30
 BOOL:     skip_ego
 
 NAME:     orange crystal plate armour
@@ -1217,6 +1230,7 @@ TILE_EQ: majin
 MP:      6
 INT:     6
 BRAND:   SPWPN_VAMPIRISM
+BOOL:    notac
 
 ENUM:    GYRE
 NAME:    pair of quick blades "Gyre" and "Gimble"
@@ -1227,7 +1241,7 @@ TILE:    urand_gyre
 TILE_EQ: gyre
 PLUS:    5
 BRAND:   SPWPN_VORPAL
-DEX:     -3
+DEX:     3
 
 ENUM:    ETHERIC_CAGE
 NAME:    Maxwell's etheric cage
@@ -1238,7 +1252,7 @@ TILE_EQ: etheric_cage
 INSCRIP: RegenMP+
 PLUS:    +0
 MP:      +4
-BOOL:    mutate, elec, chaotic
+BOOL:    mutate, elec, chaotic, notac
 VALUE:   400
 
 ENUM:    ETERNAL_TORMENT


### PR DESCRIPTION
SWORD OF POWER - changed to triple sword
CROWN OF DIPROZACIA - change to helmet (1AC)
SNAKEBITE - changed to demon whip, what can I say except you're welcome
RING OF PHASING - upgraded to +12 to compete with the relative worthlessness of EV vs AC
OCTOPUS RINGS - upgraded to +2 so there might be a reason to wear them 
ARC BLADE - base damage +2
LAJ OF ORDER - upgraded to +9
THERMIC ENGINE - gives rf+ and rc+ instead of -. the sword still sucks.
FISTS OF THUNDER - upgraded to Slay 4
WYRMBANE - nerfed it, just kidding, didn't touch it, it's still perfect

LEAR'S HAUBERK: added rN+++ and MR+++
SKIN OF ZHOR: made +8, added regen, added rmsl
SALAMANDER HIDE: made +8, changed from rF++ to rF+++, added slay 6
MAXWELLS: removed -tele, added clarity
ROBE OF NIGHT: added evocable fog, blink, fly, and invisibility
ROBES OF FOLLY AND MISFORTUNE: added "notac" flag so will not spawn in crates
ROBE OF AUGMENTATION: +8 adds 8 to all stats

CLOAK OF FOG: removed slay malus, added evocable blink
RATSKIN CLOAK: added rC, rCorr, removed -1 INT. 
HAT OF ALCHEMIST: changed to +1, changed name to "hatte of the Alchememist"
FENCER'S GLOVES: now +5 with dex +10 since riposte sucks