### PR TITLE
Allow masks and crowns with antenna and horns

### DIFF
--- a/crawl-ref/source/item-use.cc
+++ b/crawl-ref/source/item-use.cc
@@ -952,15 +952,21 @@ bool can_wear_armour(const item_def &item, bool verbose, bool ignore_temporary)
 
     if (slot == EQ_HELMET)
     {
-        // Horns 3 & Antennae 3 mutations disallow all headgear
-        if (you.get_mutation_level(MUT_HORNS, false) == 3)
+                // Horns 3 & Antennae 3 mutations disallow all headgear except crowns and masks
+        if (you.get_mutation_level(MUT_HORNS, false) == 3
+            && !is_unrandom_artefact(item, UNRAND_ETERNAL_TORMENT)
+            && !is_unrandom_artefact(item, UNRAND_CROWN_OF_DYROVEPREVA)
+            && !is unrandom_artefact(item, UNRAND_DRAGONMASK))
         {
             if (verbose)
                 mpr("You can't wear any headgear with your large horns!");
             return false;
         }
 
-        if (you.get_mutation_level(MUT_ANTENNAE, false) == 3)
+        if (you.get_mutation_level(MUT_ANTENNAE, false) == 3
+            && !is_unrandom_artefact(item, UNRAND_ETERNAL_TORMENT)
+            && !is_unrandom_artefact(item, UNRAND_CROWN_OF_DYROVEPREVA)
+            && !is_unrandom_artefact(item, UNRAND_DRAGONMASK))
         {
             if (verbose)
                 mpr("You can't wear any headgear with your large antennae!");

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1818,9 +1818,12 @@ bool mutate(mutation_type which_mutation, const string &reason, bool failMsg,
         case MUT_HORNS:
         case MUT_ANTENNAE:
             // Horns & Antennae 3 removes all headgear. Same algorithm as with
-            // glove removal.
+            // glove removal except allow masks and crowns
+            if (cur_base_level >= 3 && !you.melded[EQ_HELMET]
+                && !player_equip_unrand(UNRAND_ETERNAL_TORMENT)
+                && !player_equip_unrand(UNRAND_CROWN_OF_DYROVEPREVA)
+                && !player_equip_unrand(UNRAND_DRAGONMASK))
 
-            if (cur_base_level >= 3 && !you.melded[EQ_HELMET])
                 remove_one_equip(EQ_HELMET, false, true);
             // Intentional fall-through
         case MUT_BEAK:


### PR DESCRIPTION
Not sure if this will entirely bypass the checks but this should allow Formicid and Demonspawn as well as anyone else with antennae or horns 3 to equip crown and mask artefacts.  May still not generate these for acquirement or gifts but if they are found they can be equipped.