### PR TITLE
Fix saves that load with PLEDGE_UNKNOWN

### DIFF
--- a/crawl-ref/source/tags.cc
+++ b/crawl-ref/source/tags.cc
@@ -2258,6 +2258,12 @@ void tag_read_char(reader &th, uint8_t format, uint8_t major, uint8_t minor)
     if (major > 34 || major == 34 && minor >= 198)
     {
         you.pledge = static_cast<pledge_type>(unmarshallUByte(th));
+        
+        // In case of bad saves/loads, fix save by changing to none
+        if (you.pledge == PLEDGE_UNKNOWN)
+        {
+            you.pledge = PLEDGE_NONE;
+        }
     }
     else
     {


### PR DESCRIPTION
I guess this was due to a server hiccup? TODO: Find out how other save
information is preserved across crashes/reloads.