### PR TITLE
Initial Jiyva Changes

### DIFF
--- a/crawl-ref/source/ability.cc
+++ b/crawl-ref/source/ability.cc
@@ -502,7 +502,7 @@ static const ability_def Ability_List[] =
     { ABIL_JIYVA_SLIMIFY, "Slimify",
       4, 0, 0, 8, {fail_basis::invo, 90, 0, 2}, abflag::none },
     { ABIL_JIYVA_CURE_BAD_MUTATION, "Cure Bad Mutation",
-      0, 0, 0, 15, {fail_basis::invo}, abflag::none },
+      0, 0, 0, 10, {fail_basis::invo}, abflag::none },
 
     // Fedhas
     { ABIL_FEDHAS_FUNGAL_BLOOM, "Fungal Bloom",

--- a/crawl-ref/source/artefact.cc
+++ b/crawl-ref/source/artefact.cc
@@ -51,8 +51,9 @@ static bool _god_fits_artefact(const god_type which_god, const item_def &item,
         return false;
 
     // Jellies can't eat artefacts, so their god won't make any.
-    if (which_god == GOD_JIYVA)
-        return false;
+    // WHAT?  FUCK THAT
+    //if (which_god == GOD_JIYVA)
+    //    return false;
 
     // First check the item's base_type and sub_type, then check the
     // item's brand and other randart properties.

--- a/crawl-ref/source/god-prayer.cc
+++ b/crawl-ref/source/god-prayer.cc
@@ -272,7 +272,7 @@ static slurp_gain _sacrifice_one_item_noncount(const item_def& item)
         && x_chance_in_y(you.piety, MAX_PIETY)
         && you.magic_points < you.max_magic_points)
     {
-        inc_mp(max(random2(item_value), 1));
+        inc_mp(max(random2(item_value), 2));
         gain.jiyva_bonus |= jiyva_slurp_result::mp;
     }
 
@@ -281,7 +281,7 @@ static slurp_gain _sacrifice_one_item_noncount(const item_def& item)
         && you.hp < you.hp_max
         && !you.duration[DUR_DEATHS_DOOR])
     {
-        inc_hp(max(random2(item_value), 1));
+        inc_hp(max(random2(item_value), 2));
         gain.jiyva_bonus |= jiyva_slurp_result::hp;
     }
 

--- a/crawl-ref/source/jiyva
+++ b/crawl-ref/source/jiyva
@@ -1,0 +1,12 @@
+changed chance to eat offlevel item from 1 in 25 to 1 in 500
+reduced piety cost to cure bad mutation from 15 to 10
+changed minimum hp and mp healing to 2 instead of 1
+removed something about jiyva not allowing artefacts to be created
+give rank of evolution on joining jiyva
+evolution will not remove itself if you worship Jiyva  
+doubled chance of gift activating after timeout 
+reduced gift timeout from 15+2d4 to 8+2d3
+GIFTS - cut chance of removing mutations from 5%/25% to 2%/8% 
+GIFTS - added 5% chance to remove a bad mutatoin
+GIFTS - changed chance of random/slime/good mut to 20/25/30
+review _demon_facets and  _order_ds_mutations()

--- a/crawl-ref/source/mutation.cc
+++ b/crawl-ref/source/mutation.cc
@@ -1540,7 +1540,7 @@ bool undead_mutation_rot()
  * @param force_mutation    whether to override mutation protection and the like.
  * @param god_gift          is this a god gift? Entails overriding mutation resistance if not forced.
  * @param mutclass          is the mutation temporary, regular, or permanent (innate)? permanent entails force_mutation.
- *
+ * @param permabuff         this is a permabuff (spell) mutation - default is false
  * @return whether the mutation succeeded.
  */
 bool mutate(mutation_type which_mutation, const string &reason, bool failMsg,

--- a/crawl-ref/source/religion.cc
+++ b/crawl-ref/source/religion.cc
@@ -1065,14 +1065,17 @@ static bool _jiyva_mutate()
     simple_god_message(" alters your body.");
 
     const int rand = random2(100);
-
-    if (rand < 5)
+    // 2% delete slime mut, 8% delete mut, 5% delete bad mut
+    // 20% random mut, 35% random slime mut, 30% good mut
+    if (rand < 2)
         return delete_mutation(RANDOM_SLIME_MUTATION, "Jiyva's grace", true, false, true);
-    else if (rand < 30)
+    else if (rand < 10)
         return delete_mutation(RANDOM_NON_SLIME_MUTATION, "Jiyva's grace", true, false, true);
-    else if (rand < 55)
+    else if (rand < 15)
+        return delete_mutation(RANDOM_BAD_MUTATION, "Jiyva's grace", true, false, true);
+    else if (rand < 35)
         return mutate(RANDOM_MUTATION, "Jiyva's grace", true, false, true);
-    else if (rand < 75)
+    else if (rand < 70)
         return mutate(RANDOM_SLIME_MUTATION, "Jiyva's grace", true, false, true);
     else
         return mutate(RANDOM_GOOD_MUTATION, "Jiyva's grace", true, false, true);
@@ -1428,12 +1431,12 @@ static bool _gift_jiyva_gift(bool forced)
 {
     if (forced || you.piety >= piety_breakpoint(2)
                   && random2(you.piety) > 50
-                  && one_chance_in(4) && !you.gift_timeout
+                  && one_chance_in(2) && !you.gift_timeout
                   && you.can_safely_mutate())
     {
         if (_jiyva_mutate())
         {
-            _inc_gift_timeout(15 + roll_dice(2, 4));
+            _inc_gift_timeout(8 + roll_dice(2, 3));
             you.num_current_gifts[you.religion]++;
             you.num_total_gifts[you.religion]++;
             return true;
@@ -2764,6 +2767,11 @@ void excommunication(bool voluntary, god_type new_god)
 
     switch (old_god)
     {
+    case GOD_JIYVA:
+        mprf(MSGCH_GOD, old_god, "You no longer evolve innately."); 
+         you.innate_mutation[MUT_EVOLUTION]--;
+        break;
+
     case GOD_KIKUBAAQUDGHA:
         mprf(MSGCH_GOD, old_god, "You sense decay."); // in the state of Denmark
         add_daction(DACT_ROT_CORPSES);
@@ -3498,6 +3506,8 @@ static void _join_hepliaklqana()
 /// Setup when joining the gelatinous groupies of Jiyva.
 static void _join_jiyva()
 {
+    // give innate rank of evolution
+    you.mutate(MUT_EVOLUTION,"Jiyva's grace",false,true,true,true,MUTCLASS_INNATE,false)
     // Complimentary jelly upon joining.
     if (_has_jelly())
         return;

--- a/crawl-ref/source/timed-effects.cc
+++ b/crawl-ref/source/timed-effects.cc
@@ -890,7 +890,8 @@ static void _jiyva_effects(int /*time_delta*/)
         jiyva_stat_action();
     }
 
-    if (have_passive(passive_t::jelly_eating) && one_chance_in(25))
+    // 1 in 25 for vanilla crawl
+    if (have_passive(passive_t::jelly_eating) && one_chance_in(500))
         jiyva_eat_offlevel_items();
 }
 
@@ -909,6 +910,7 @@ static void _evolve(int time_delta)
                        "evolution", false, false, false, false, MUTCLASS_NORMAL);
             // it would kill itself anyway, but let's speed that up
             if (one_chance_in(10)
+                && (!(god == GOD_JIYVA))
                 && (!you.rmut_from_item()
                     || one_chance_in(10)))
             {


### PR DESCRIPTION
changed chance to eat offlevel item from 1 in 25 to 1 in 500
reduced piety cost to cure bad mutation from 15 to 10
changed minimum hp and mp healing to 2 instead of 1
removed something about jiyva not allowing artefacts to be created
give innate rank of evolution on joining jiyva
make evolution non-innate leaving jiyva
evolution will not remove itself if you worship Jiyva
doubled chance of gift activating after timeout
reduced gift timeout from 15+2d4 to 8+2d3
GIFTS - cut chance of removing mutations from 5%/25% to 2%/8%
GIFTS - added 5% chance to remove a bad mutatoin
GIFTS - changed chance of random/slime/good mut to 20/25/30