### PR TITLE
Porting vanilla monster item identification

### DIFF
--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -44,6 +44,7 @@
 #include "message.h"
 #include "mon-act.h"
 #include "mon-behv.h"
+#include "mon-gear.h"
 #include "mon-tentacle.h"
 #include "mon-util.h"
 #include "mutation.h"
@@ -1124,8 +1125,8 @@ static inline bool _monster_warning(activity_interrupt_type ai,
         return false;
     else
     {
-        ash_id_monster_equipment(mon);
-        mark_mon_equipment_seen(mon);
+        view_monster_equipment(mon);
+        do_conversions(mon);
 
         string text = getMiscString(mon->name(DESC_DBNAME) + " title");
         if (text.empty())
@@ -1171,7 +1172,6 @@ static inline bool _monster_warning(activity_interrupt_type ai,
         else
             text += " comes into view.";
 
-        bool ash_id = mon->props.exists("ash_id") && mon->props["ash_id"];
         bool zin_id = false;
         string god_warning;
 
@@ -1179,7 +1179,6 @@ static inline bool _monster_warning(activity_interrupt_type ai,
             && mon->is_shapeshifter()
             && !(mon->flags & MF_KNOWN_SHIFTER))
         {
-            ASSERT(!ash_id);
             zin_id = true;
             mon->props["zin_id"] = true;
             discover_shifter(*mon);
@@ -1194,22 +1193,13 @@ static inline bool _monster_warning(activity_interrupt_type ai,
 
         monster_info mi(mon);
 
-        const string mweap = get_monster_equipment_desc(mi,
-                                                        ash_id ? DESC_IDENTIFIED
-                                                               : DESC_WEAPON,
+        const string mweap = get_monster_equipment_desc(mi, DESC_IDENTIFIED,
                                                         DESC_NONE);
 
         if (!mweap.empty())
         {
-            if (ash_id)
-            {
-                god_warning = uppercase_first(god_name(you.religion))
-                              + " warns you:";
-            }
-
-            (ash_id ? god_warning : text) +=
-                " " + uppercase_first(mon->pronoun(PRONOUN_SUBJECTIVE)) + " is"
-                + (ash_id ? " " : "")
+            text += " " + uppercase_first(mon->pronoun(PRONOUN_SUBJECTIVE)) + " is"
+                + (mweap[0] != ' ' ? " " : "")
                 + mweap + ".";
         }
 
@@ -1218,7 +1208,7 @@ static inline bool _monster_warning(activity_interrupt_type ai,
         else
         {
             mprf(MSGCH_MONSTER_WARNING, "%s", text.c_str());
-            if (ash_id || zin_id)
+            if (zin_id)
                 mprf(MSGCH_GOD, "%s", god_warning.c_str());
 #ifndef USE_TILE_LOCAL
             if (zin_id)

--- a/crawl-ref/source/delay.cc
+++ b/crawl-ref/source/delay.cc
@@ -1126,7 +1126,6 @@ static inline bool _monster_warning(activity_interrupt_type ai,
     else
     {
         view_monster_equipment(mon);
-        do_conversions(mon);
 
         string text = getMiscString(mon->name(DESC_DBNAME) + " title");
         if (text.empty())

--- a/crawl-ref/source/directn.cc
+++ b/crawl-ref/source/directn.cc
@@ -3320,7 +3320,7 @@ string get_monster_equipment_desc(const monster_info& mi,
     if (mi.wields_two_weapons())
         mon_alt = 0;
 
-    const bool mon_has_wand = mi.props.exists("wand_known") && mon_wnd;
+    const bool mon_has_wand = mon_wnd;
     const bool mon_carry = mon_alt || mon_has_wand;
 
     vector<string> item_descriptions;
@@ -3368,12 +3368,7 @@ string get_monster_equipment_desc(const monster_info& mi,
         }
 
         if (mon_has_wand)
-        {
-            if (mi.props["wand_known"])
-                carried_desc += mon_wnd->name(DESC_A);
-            else
-                carried_desc += "a wand";
-        }
+            carried_desc += mon_wnd->name(DESC_A);
 
         item_descriptions.push_back(carried_desc);
     }

--- a/crawl-ref/source/god-passive.cc
+++ b/crawl-ref/source/god-passive.cc
@@ -850,40 +850,6 @@ bool god_id_item(item_def& item, bool silent)
     return false;
 }
 
-void ash_id_monster_equipment(monster* mon)
-{
-    if (!have_passive(passive_t::identify_items))
-        return;
-
-    bool id = false;
-
-    for (unsigned int i = 0; i <= MSLOT_LAST_VISIBLE_SLOT; ++i)
-    {
-        if (mon->inv[i] == NON_ITEM)
-            continue;
-
-        item_def &item = mitm[mon->inv[i]];
-        if ((i != MSLOT_WAND || !is_offensive_wand(item))
-            && !item_is_branded(item))
-        {
-            continue;
-        }
-
-        if (i == MSLOT_WAND)
-        {
-            set_ident_type(OBJ_WANDS, item.sub_type, true);
-            mon->props["wand_known"] = true;
-        }
-        else
-            set_ident_flags(item, ISFLAG_KNOW_TYPE);
-
-        id = true;
-    }
-
-    if (id)
-        mon->props["ash_id"] = true;
-}
-
 static bool is_ash_portal(dungeon_feature_type feat)
 {
     if (feat_is_portal_entrance(feat))

--- a/crawl-ref/source/god-passive.h
+++ b/crawl-ref/source/god-passive.h
@@ -277,7 +277,6 @@ void ash_init_bondage(player *y);
 void ash_check_bondage(bool msg = true);
 string ash_describe_bondage(int flags, bool level);
 bool god_id_item(item_def& item, bool silent = true);
-void ash_id_monster_equipment(monster* mon);
 int ash_detect_portals(bool all);
 monster_type ash_monster_tier(const monster *mon);
 unsigned int ash_skill_point_boost(skill_type sk, int scaled_skill);

--- a/crawl-ref/source/mon-act.cc
+++ b/crawl-ref/source/mon-act.cc
@@ -1098,22 +1098,10 @@ static void _mons_fire_wand(monster& mons, item_def &wand, bolt &beem,
 
     if (was_visible)
     {
-        const int wand_type = wand.sub_type;
-
-        set_ident_type(OBJ_WANDS, wand_type, true);
-        if (!mons.props["wand_known"].get_bool())
-            mprf("It is %s.", wand.name(DESC_A).c_str());
-
         if (wand.charges <= 0)
-        {
-            mons.props["wand_known"] = false;
             mprf("The now-empty wand crumbles to dust.");
-        }
         else
-        {
-            mons.props["wand_known"] = true;
             mons.flags |= MF_SEEN_RANGED;
-        }
     }
 
     if (wand.charges <= 0)

--- a/crawl-ref/source/mon-gear.cc
+++ b/crawl-ref/source/mon-gear.cc
@@ -2219,3 +2219,16 @@ void give_item(monster *mons, int level_number, bool mons_summoned)
     _give_armour(mons, 1 + level_number / 2);
     _give_shield(mons, 1 + level_number / 2);
 }
+
+void view_monster_equipment(monster* mon)
+{
+    for (unsigned int i = 0; i <= MSLOT_LAST_VISIBLE_SLOT; ++i)
+    {
+        if (mon->inv[i] == NON_ITEM)
+            continue;
+
+        item_def &item = mitm[mon->inv[i]];
+        item.flags |= ISFLAG_SEEN;
+        set_ident_flags(item, ISFLAG_IDENT_MASK);
+    }
+}

--- a/crawl-ref/source/mon-gear.h
+++ b/crawl-ref/source/mon-gear.h
@@ -13,3 +13,4 @@ void give_weapon(monster *mon, int level_number);
 int make_mons_armour(monster_type mtyp, int level);
 void give_armour(monster *mon, int level_number);
 void give_shield(monster *mon);
+void view_monster_equipment(monster* mon);

--- a/crawl-ref/source/mon-info.cc
+++ b/crawl-ref/source/mon-info.cc
@@ -184,7 +184,6 @@ static bool _blocked_ray(const coord_def &where,
 static bool _is_public_key(string key)
 {
     if (key == "helpless"
-     || key == "wand_known"
      || key == "feat_type"
      || key == "glyph"
      || key == "dbname"
@@ -688,10 +687,6 @@ monster_info::monster_info(const monster* m, int milev)
         else if (i == MSLOT_MISCELLANY)
             ok = false;
         else if (attitude == ATT_FRIENDLY)
-            ok = true;
-        else if (i == MSLOT_WAND)
-            ok = props.exists("wand_known") && props["wand_known"];
-        else if (m->props.exists("ash_id") && item_type_known(mitm[m->inv[i]]))
             ok = true;
         else if (i == MSLOT_ALT_WEAPON)
             ok = wields_two_weapons();

--- a/crawl-ref/source/mon-poly.cc
+++ b/crawl-ref/source/mon-poly.cc
@@ -632,7 +632,6 @@ void seen_monster(monster* mons)
     item_def* weapon = mons->weapon();
     if (weapon && is_range_weapon(*weapon))
         mons->flags |= MF_SEEN_RANGED;
-    mark_mon_equipment_seen(mons);
 
     // Monster was viewed this turn
     mons->flags |= MF_WAS_IN_VIEW;

--- a/crawl-ref/source/mon-poly.cc
+++ b/crawl-ref/source/mon-poly.cc
@@ -24,6 +24,7 @@
 #include "libutil.h"
 #include "message.h"
 #include "mon-death.h"
+#include "mon-gear.h"
 #include "mon-place.h"
 #include "mon-tentacle.h"
 #include "notes.h"
@@ -628,6 +629,8 @@ void seen_monster(monster* mons)
     // set an exclusion.
     set_auto_exclude(mons);
     set_unique_annotation(mons);
+
+    view_monster_equipment(mons);
 
     item_def* weapon = mons->weapon();
     if (weapon && is_range_weapon(*weapon))

--- a/crawl-ref/source/monster.cc
+++ b/crawl-ref/source/monster.cc
@@ -1242,9 +1242,6 @@ bool monster::drop_item(mon_inv_type eslot, bool msg)
         }
     }
 
-    if (props.exists("wand_known") && msg && was_wand)
-        props.erase("wand_known");
-
     inv[eslot] = NON_ITEM;
     return true;
 }
@@ -2016,11 +2013,7 @@ bool monster::pickup_wand(item_def &item, bool msg, bool force)
     }
 
     if (pickup(item, MSLOT_WAND, msg))
-    {
-        if (msg)
-            props["wand_known"] = item_type_known(item);
         return true;
-    }
     else
         return false;
 }

--- a/crawl-ref/source/props.h
+++ b/crawl-ref/source/props.h
@@ -17,12 +17,5 @@
 
     monster keys
     public
-    "wand_known" For wands, we can't simply rely on item knowledge, because
-    if the player has already identified the wand type, item_type_known
-    returns true regarding player's knowledge of this specific wand.
-    Thus, we track wand knowledge using this key.
-    If the property exists, it means the player knows the monster has a wand.
-    If it's true, the player also knows it's type.
-
     private
 */

--- a/crawl-ref/source/view.cc
+++ b/crawl-ref/source/view.cc
@@ -279,18 +279,17 @@ static string _monster_headsup(const vector<monster*> &monsters,
     string warning_msg = "";
     for (const monster* mon : monsters)
     {
-        const bool ash_ided = mon->props.exists("ash_id");
         const bool zin_ided = mon->props.exists("zin_id");
         const bool has_branded_weapon
             = _is_weapon_worth_listing(mon->weapon())
               || _is_weapon_worth_listing(mon->weapon(1));
-        if ((divine && !ash_ided && !zin_ided)
+        if ((divine && !zin_ided)
             || (!divine && !has_branded_weapon))
         {
             continue;
         }
 
-        if (!divine && (ash_ided || monsters.size() == 1))
+        if (!divine && monsters.size() == 1)
             continue; // don't give redundant warnings for enemies
 
         monster_info mi(mon);
@@ -524,31 +523,6 @@ void update_monsters_in_view()
     {
         you.attribute[ATTR_ABYSS_ENTOURAGE] = num_hostile;
         xom_is_stimulated(12 * num_hostile);
-    }
-}
-
-void mark_mon_equipment_seen(const monster *mons)
-{
-    // mark items as seen.
-    for (int slot = MSLOT_WEAPON; slot <= MSLOT_LAST_VISIBLE_SLOT; slot++)
-    {
-        int item_id = mons->inv[slot];
-        if (item_id == NON_ITEM)
-            continue;
-
-        item_def &item = mitm[item_id];
-
-        item.flags |= ISFLAG_SEEN;
-
-        // ID brands of weapons held by enemies.
-        if (slot == MSLOT_WEAPON
-            || slot == MSLOT_ALT_WEAPON && mons_wields_two_weapons(*mons))
-        {
-            if (is_artefact(item))
-                artefact_learn_prop(item, ARTP_BRAND);
-            else
-                item.flags |= ISFLAG_KNOW_TYPE;
-        }
     }
 }
 

--- a/crawl-ref/source/view.h
+++ b/crawl-ref/source/view.h
@@ -75,7 +75,6 @@ void draw_cell(screen_cell_t *cell, const coord_def &gc,
 void update_monsters_in_view();
 bool handle_seen_interrupt(monster* mons, vector<string>* msgs_buf = nullptr);
 void flush_comes_into_view();
-void mark_mon_equipment_seen(const monster *mons);
 void toggle_show_terrain();
 void reset_show_terrain();
 


### PR DESCRIPTION
Should now just ID all monster gear on sight. Seems to remove all references to Ash IDing monster items.